### PR TITLE
Support cancellation.

### DIFF
--- a/ZipContent.Core/Readers/IPartialFileReader.cs
+++ b/ZipContent.Core/Readers/IPartialFileReader.cs
@@ -1,11 +1,15 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace ZipContent.Core
 {
     public interface IPartialFileReader
     {
-         Task<long> ContentLength();
-         Task<byte[]> GetBytes(ByteRange range);
-    }
+        Task<long> ContentLength();
+        Task<byte[]> GetBytes(ByteRange range);
 
+        Task<long> ContentLength(CancellationToken cancellation);
+
+        Task<byte[]> GetBytes(ByteRange range, CancellationToken cancellation);
+    }
 }

--- a/ZipContent.Core/Readers/PartialFileReader.cs
+++ b/ZipContent.Core/Readers/PartialFileReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ZipContent.Core
@@ -13,21 +14,43 @@ namespace ZipContent.Core
             _fileInfo = new FileInfo($"{folder}/{fileName}");
         }
 
-        public async Task<long> ContentLength()
+        public Task<long> ContentLength()
         {
-            using (var docStream = _fileInfo.OpenRead())
-                return docStream.Length;
+            var task = new Task<long>(() =>
+            {
+                using (var docStream = _fileInfo.OpenRead())
+                {
+                    return docStream.Length;
+                }
+            });
+            task.RunSynchronously(TaskScheduler.Current);
+            return task;
         }
 
-        public async Task<byte[]> GetBytes(ByteRange range)
+        public Task<byte[]> GetBytes(ByteRange range)
         {
-            var stream = _fileInfo.OpenRead();
-            var br = new BinaryReader(stream);
+            var task = new Task<byte[]>(() =>
+            {
+                var stream = _fileInfo.OpenRead();
+                var br = new BinaryReader(stream);
 
-            byte[] dataArray = new byte[Convert.ToInt32(range.End - range.Start)];
-            stream.Seek(Convert.ToInt32(range.Start), SeekOrigin.Begin);
+                byte[] dataArray = new byte[Convert.ToInt32(range.End - range.Start)];
+                stream.Seek(Convert.ToInt32(range.Start), SeekOrigin.Begin);
 
-            return br.ReadBytes(Convert.ToInt32(range.End - range.Start));
+                return br.ReadBytes(Convert.ToInt32(range.End - range.Start));
+            });
+            task.RunSynchronously(TaskScheduler.Current);
+            return task;
+        }
+
+        public Task<long> ContentLength(CancellationToken cancellation)
+        {
+            return ContentLength();
+        }
+
+        public Task<byte[]> GetBytes(ByteRange range, CancellationToken cancellation)
+        {
+            return GetBytes(range);
         }
     }
 }


### PR DESCRIPTION
Since most networking modules and SDKs support cancellation, it’s logical to make the async reader interface methods take `CancellationToken`.

If certain SDKs don't, there's no harm taking one.

If the user doesn’t need cancellation, they can pass `default` to fulfill the contract.

I duplicated original methods to take cancellation token. But ideally one of these two approaches are better:

1. Remove original methods. Interface requirements will be changed but calling signature is unchanged if no cancellation token should be given. Implementors must add `= default` to method signatures.
2. If targeting C# 8 and above, provide default implementation in the interface for cancellation supporting methods to call non-cancellable method. Interface requirements are the same as old one if not using cancellation.